### PR TITLE
Fix compilation on gcc 6 and clang

### DIFF
--- a/src/playlist/proxymodels/SortAlgorithms.cpp
+++ b/src/playlist/proxymodels/SortAlgorithms.cpp
@@ -95,7 +95,9 @@ multilevelLessThan::operator()( const QAbstractItemModel* sourceModel,
                         return ( compareResult < 0 ) != inverted;
 
                     // Fall through to sorting by album artist if albums have same name
-                    __attribute__ ((fallthrough));
+                    #if defined(__has_cpp_attribute) && __has_cpp_attribute(fallthrough)
+                    [[fallthrough]]
+                    #endif
                 }
                 case Playlist::AlbumArtist:
                 {

--- a/src/playlist/proxymodels/SortAlgorithms.cpp
+++ b/src/playlist/proxymodels/SortAlgorithms.cpp
@@ -96,7 +96,7 @@ multilevelLessThan::operator()( const QAbstractItemModel* sourceModel,
 
                     // Fall through to sorting by album artist if albums have same name
                     #if defined(__has_cpp_attribute) && __has_cpp_attribute(fallthrough)
-                    [[fallthrough]]
+                    [[fallthrough]];
                     #endif
                 }
                 case Playlist::AlbumArtist:


### PR DESCRIPTION
__attribute__((fallthrough)) is gcc 7+, this syntax is C++17 compliant and I check for its availability before using it in order to be backward/clang compatible.