### PR TITLE
Fix compatibility with modern MySQL

### DIFF
--- a/src/core-impl/storage/sql/mysql-shared/MySqlStorage.h
+++ b/src/core-impl/storage/sql/mysql-shared/MySqlStorage.h
@@ -19,6 +19,7 @@
 #define AMAROK_STORAGE_MYSQLSTORAGE_H
 
 #include "core/storage/SqlStorage.h"
+#include <mysql/mysql.h>
 
 
 #include <QMutex>
@@ -28,8 +29,9 @@
   #include <winsock2.h>
 #endif
 
-struct st_mysql;
-typedef struct st_mysql MYSQL;
+#if !defined(MARIADB_VERSION_ID) && MYSQL_VERSION_ID >= 80000
+using my_bool = bool;
+#endif
 
 /**
  * Implements a SqlStorage using a MySQL backend

--- a/tests/core-impl/collections/CMakeLists.txt
+++ b/tests/core-impl/collections/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory( aggregate )
-add_subdirectory( db/sql )
+if( BUILD_MYSQLE_COLLECTION )
+    add_subdirectory( db/sql )
+endif()
 add_subdirectory( support )


### PR DESCRIPTION
MySQL 8.0 onward changed a few details in the client API, and embedded support has apparently been removed completely. This PR makes minimally invasive changes that fix the related compile errors in a (hopefully) backward compatible manner.

Please let me know if I should submit the PR somewhere else.