### PR TITLE
Tweak to improve appearance when Context is scaled narrowly.

### DIFF
--- a/src/context/applets/currenttrack/package/contents/ui/main.qml
+++ b/src/context/applets/currenttrack/package/contents/ui/main.qml
@@ -28,8 +28,8 @@ AmarokQml.Applet {
     Loader {
         id: cover
 
-        height: parent.height
-        width: height
+        width: parent.width/2
+        height: width
 
         sourceComponent: CurrentTrackEngine.hasValidCover ? coverComponent : emptyComponent
     }
@@ -55,15 +55,7 @@ AmarokQml.Applet {
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignLeft
             }
-            AmarokQml.RatingItem {
-                id: ratingItem
 
-                Layout.preferredWidth: height * 6
-                Layout.preferredHeight: parent.height / 5
-                Layout.alignment: Qt.AlignTop | Qt.AlignRight
-                rating: CurrentTrackEngine.rating
-                onClicked: CurrentTrackEngine.rating = newRating
-            }
         }
         StatsItem {
             id: statsItem
@@ -72,6 +64,17 @@ AmarokQml.Applet {
             Layout.alignment: Qt.AlignBottom
             Layout.preferredHeight: parent.height / 5
         }
+
+        AmarokQml.RatingItem {
+            id: ratingItem
+
+            Layout.preferredWidth: height * 5
+            Layout.preferredHeight: parent.height / 8
+            Layout.alignment: Qt.AlignTop | Qt.AlignRight
+            rating: CurrentTrackEngine.rating
+            onClicked: CurrentTrackEngine.rating = newRating
+        }
+
     }
 
     Component {


### PR DESCRIPTION
The Current Track context widget rendered very uglily when the Context component was narrow. On a small monitor, or when Amarok is non-maximized, the 3 columns were too many columns. 

This tweak could be improved further if the RatingItem were moved to a position below the album cover, but I am not sure if that would create the impression that the rating was for the album, rather than the track.
